### PR TITLE
Make visual-logging python 3 compatible

### DIFF
--- a/vlogging/__init__.py
+++ b/vlogging/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import StringIO
+from io import StringIO
 from string import Template
 import base64
 


### PR DESCRIPTION
The StringIO module was removed from Python 3 and moved underneath the io module.  io.StringIO is present in both Python 2 and 3.  
